### PR TITLE
Implement MCP stdio server mode

### DIFF
--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -1,0 +1,33 @@
+"""Tests for MCP integration."""
+
+from __future__ import annotations
+
+import json
+from tooli import Tooli
+from tooli.testing import TooliTestClient
+
+
+def test_mcp_export() -> None:
+    """mcp export should output valid MCP tool definitions."""
+    app = Tooli(name="test-mcp")
+
+    @app.command()
+    def greet(name: str) -> str:
+        """Greet someone."""
+        return f"Hello {name}"
+
+    @app.command()
+    def noop() -> None:
+        pass
+
+    client = TooliTestClient(app)
+    result = client.invoke(["mcp", "export"])
+    assert result.exit_code == 0
+    
+    tools = json.loads(result.output)
+    assert isinstance(tools, list)
+    assert len(tools) >= 2
+    
+    greet_tool = next(t for t in tools if t["name"] == "greet")
+    assert greet_tool["description"] == "Greet someone."
+    assert "name" in greet_tool["inputSchema"]["properties"]

--- a/tooli/app.py
+++ b/tooli/app.py
@@ -51,6 +51,30 @@ class Tooli(typer.Typer):
             import click
             click.echo("Generated SKILL.md")
 
+        # MCP group
+        import typer
+        mcp_app = typer.Typer(name="mcp", help="MCP server utilities", hidden=True)
+        self.add_typer(mcp_app)
+
+        @mcp_app.command(name="export")
+        def mcp_export() -> None:
+            """Export MCP tool definitions as JSON."""
+            from tooli.mcp.export import export_mcp_tools
+            import json
+            import click
+            tools = export_mcp_tools(self)
+            click.echo(json.dumps(tools, indent=2))
+
+        @mcp_app.command(name="serve")
+        def mcp_serve(
+            transport: str = typer.Option("stdio", help="MCP transport: stdio|http|sse"),
+            host: str = typer.Option("localhost", help="HTTP/SSE host"),
+            port: int = typer.Option(8080, help="HTTP/SSE port"),
+        ) -> None:
+            """Run the application as an MCP server."""
+            from tooli.mcp.server import serve_mcp
+            serve_mcp(self, transport=transport, host=host, port=port)
+
     def command(
         self,
         name: str | None = None,

--- a/tooli/mcp/__init__.py
+++ b/tooli/mcp/__init__.py
@@ -1,0 +1,6 @@
+"""MCP integration for Tooli."""
+
+from tooli.mcp.export import export_mcp_tools
+from tooli.mcp.server import serve_mcp
+
+__all__ = ["export_mcp_tools", "serve_mcp"]

--- a/tooli/mcp/export.py
+++ b/tooli/mcp/export.py
@@ -5,20 +5,19 @@ from __future__ import annotations
 import json
 from typing import TYPE_CHECKING, Any
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ConfigDict
 
 if TYPE_CHECKING:
     from tooli.app import Tooli
 
 
 class MCPToolDefinition(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
     name: str
     description: str
     input_schema: dict[str, Any] = Field(alias="inputSchema")
     annotations: dict[str, Any] | None = None
-
-    class Config:
-        populate_by_name = True
 
 
 def export_mcp_tools(app: Tooli) -> list[dict[str, Any]]:

--- a/tooli/mcp/server.py
+++ b/tooli/mcp/server.py
@@ -1,0 +1,60 @@
+"""MCP server implementation for Tooli."""
+
+from __future__ import annotations
+
+import logging
+import sys
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from tooli.app import Tooli
+
+
+def serve_mcp(
+    app: Tooli,
+    transport: str = "stdio",
+    host: str = "localhost",
+    port: int = 8080,
+) -> None:
+    """Run the Tooli app as an MCP server."""
+    try:
+        from fastmcp import FastMCP
+    except ImportError:
+        print("Error: fastmcp is not installed. Install it with 'pip install fastmcp'.")
+        sys.exit(1)
+
+    mcp = FastMCP(name=app.info.name or "tooli-app")
+
+    # Register each Tooli command as an MCP tool
+    for cmd in app.registered_commands:
+        if cmd.hidden:
+            continue
+
+        cmd_id = cmd.name or cmd.callback.__name__
+        
+        # behavioral hints
+        from tooli.annotations import ToolAnnotation
+        annotations = getattr(cmd.callback, "__tooli_annotations__", None)
+        is_read_only = False
+        if isinstance(annotations, ToolAnnotation):
+            is_read_only = annotations.read_only
+
+        # Create a wrapper for FastMCP
+        def _make_wrapper(callback: Any) -> Any:
+            async def wrapper(**kwargs: Any) -> Any:
+                # Execute the callback directly
+                # FastMCP handles JSON serialization of the return value
+                return callback(**kwargs)
+            return wrapper
+
+        mcp.tool(name=cmd_id, description=cmd.help or cmd.callback.__doc__ or "")(_make_wrapper(cmd.callback))
+
+    # Strict stdout discipline for stdio transport
+    if transport == "stdio":
+        # Redirect logging to stderr
+        logging.basicConfig(level=logging.INFO, stream=sys.stderr)
+        mcp.run(transport="stdio")
+    else:
+        # HTTP / SSE transport (Phase 2, Issue #18)
+        # FastMCP 2.x supports http/sse
+        mcp.run(transport=transport, host=host, port=port)

--- a/tooli/testing.py
+++ b/tooli/testing.py
@@ -32,8 +32,7 @@ class TooliTestClient:
             assert "version" in payload["meta"]
             return payload
         except (json.JSONDecodeError, KeyError, AssertionError) as e:
-            raise AssertionError(f"Invalid JSON envelope: {e}
-Output: {result.output}") from e
+            raise AssertionError(f"Invalid JSON envelope: {e}\nOutput: {result.output}") from e
 
     def assert_exit_code(self, result: Result, expected_code: int) -> None:
         """Verify exit code."""


### PR DESCRIPTION
This PR implements the Model Context Protocol (MCP) integration for Tooli, including:
- An `mcp` command group with `export` and `serve` subcommands.
- Automatic generation of MCP tool definitions from Tooli command metadata and schemas.
- An MCP server implementation using FastMCP with support for stdio transport.
- Integration tests for MCP export.
- Fixes for syntax errors in the test utilities.

Closes #16, closes #17