### PR TITLE
Add MCP HTTP/SSE transport support checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,9 +119,16 @@ $ file-tools find-files --schema
 
 ```bash
 $ file-tools mcp serve --transport stdio
+$ file-tools mcp serve --transport http --host 127.0.0.1 --port 8080
 ```
 
 Add to your MCP client config and every command becomes a tool.
+
+For SSE-enabled clients, use:
+
+```bash
+$ file-tools mcp serve --transport sse --host 127.0.0.1 --port 8080
+```
 
 ## Structured Errors
 


### PR DESCRIPTION
Implements issue-driven MCP transport support.\n\n- Reject unsupported MCP transport values in serve_mcp.\n- Add unit tests to verify validation and transport forwarding to FastMCP.run.\n- Document mcp serve usage for stdio/http/sse transports.\n\nCloses #19.