### PR TITLE
Fix dry-run context detection

### DIFF
--- a/tooli/dry_run.py
+++ b/tooli/dry_run.py
@@ -61,6 +61,10 @@ def _find_tooli_context(args: tuple[Any, ...], kwargs: dict[str, Any]) -> click.
     for value in args:
         if isinstance(value, click.Context):
             return value
+
+    context = click.get_current_context(silent=True)
+    if isinstance(context, click.Context):
+        return context
     return None
 
 


### PR DESCRIPTION
Follow-up to issue #31: resolve click context from invocation context when callback does not accept ctx