### PR TITLE
Add idempotency keys for safe retries

### DIFF
--- a/tests/test_idempotency.py
+++ b/tests/test_idempotency.py
@@ -1,0 +1,60 @@
+"""Tests for command idempotency keys."""
+
+from __future__ import annotations
+
+import typer
+from typer.testing import CliRunner
+
+from tooli import Tooli
+from tooli.annotations import Idempotent
+
+
+def test_idempotent_command_reuses_cached_result_for_duplicate_key() -> None:
+    app = Tooli(name="idem-app")
+    state = {"runs": 0}
+
+    @app.command(annotations=Idempotent)
+    def increment() -> int:
+        state["runs"] += 1
+        return state["runs"]
+
+    runner = CliRunner()
+    first = runner.invoke(app, ["increment", "--idempotency-key", "k-repeat", "--text"])
+    second = runner.invoke(app, ["increment", "--idempotency-key", "k-repeat", "--text"])
+
+    assert first.exit_code == 0
+    assert second.exit_code == 0
+    assert first.output.strip() == "1"
+    assert second.output.strip() == "1"
+    assert state["runs"] == 1
+
+
+def test_non_idempotent_duplicate_key_returns_error() -> None:
+    app = Tooli(name="idem-app")
+
+    @app.command()
+    def bump() -> str:
+        return "ok"
+
+    runner = CliRunner()
+    first = runner.invoke(app, ["bump", "--idempotency-key", "k-dup", "--text"])
+    second = runner.invoke(app, ["bump", "--idempotency-key", "k-dup", "--text"])
+
+    assert first.exit_code == 0
+    assert second.exit_code != 0
+    assert "Duplicate idempotency key" in second.output
+
+
+def test_idempotency_key_visible_in_context() -> None:
+    app = Tooli(name="idem-app")
+    observed: dict[str, str | None] = {"key": None}
+
+    @app.command()
+    def report(ctx: typer.Context) -> str:
+        assert ctx.obj is not None
+        observed["key"] = ctx.obj.idempotency_key
+        return "ok"
+
+    result = CliRunner().invoke(app, ["report", "--idempotency-key", "ctx-key", "--text"])
+    assert result.exit_code == 0
+    assert observed["key"] == "ctx-key"

--- a/tooli/context.py
+++ b/tooli/context.py
@@ -24,6 +24,7 @@ class ToolContext:
     dry_run: bool = False
     force: bool = False
     yes: bool = False
+    idempotency_key: str | None = None
     timeout: float | None = None
     response_format: str = "concise"
     auth: AuthContext | None = None

--- a/tooli/idempotency.py
+++ b/tooli/idempotency.py
@@ -1,0 +1,74 @@
+"""Simple process-local idempotency tracking."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class IdempotencyRecord:
+    has_cached_result: bool
+    result: Any = None
+
+
+class IdempotencyStore:
+    """In-memory idempotency registry for the current process."""
+
+    def __init__(self) -> None:
+        self._records: dict[tuple[str, str], IdempotencyRecord] = {}
+
+    def get(self, *, command: str, idempotency_key: str) -> IdempotencyRecord | None:
+        return self._records.get((command, idempotency_key))
+
+    def put(
+        self,
+        *,
+        command: str,
+        idempotency_key: str,
+        has_cached_result: bool,
+        result: Any = None,
+    ) -> None:
+        self._records[(command, idempotency_key)] = IdempotencyRecord(
+            has_cached_result=has_cached_result,
+            result=result,
+        )
+
+    def clear(self) -> None:
+        self._records.clear()
+
+
+_global_store = IdempotencyStore()
+
+
+def get_record(*, command: str, idempotency_key: str) -> IdempotencyRecord | None:
+    """Return any stored idempotency entry for a command/key pair."""
+
+    if not idempotency_key:
+        return None
+    return _global_store.get(command=command, idempotency_key=idempotency_key)
+
+
+def set_record(
+    *,
+    command: str,
+    idempotency_key: str,
+    has_cached_result: bool,
+    result: Any = None,
+) -> None:
+    """Persist execution outcome metadata for a command/key pair."""
+
+    if not idempotency_key:
+        return
+    _global_store.put(
+        command=command,
+        idempotency_key=idempotency_key,
+        has_cached_result=has_cached_result,
+        result=result,
+    )
+
+
+def clear_records() -> None:
+    """Clear the in-memory idempotency cache."""
+
+    _global_store.clear()


### PR DESCRIPTION
Implements Issue #29: Roadmap Step 28 (idempotency key support for safe retries). Add --idempotency-key global flag, add in-memory idempotency cache in tooli/idempotency.py, store idempotency key in ToolContext, return cached results for idempotent commands and reject duplicate keys for non-idempotent commands, include keys in invocation args, and add coverage for idempotent replay, duplicate rejection, and context access. Closes #29