### PR TITLE
Implement Stream B: MCP HTTP & OpenAPI serving

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,26 @@
+"""Tests for HTTP API integration."""
+
+from __future__ import annotations
+
+import json
+from tooli import Tooli
+from tooli.testing import TooliTestClient
+
+
+def test_api_export_openapi() -> None:
+    """api export-openapi should output valid OpenAPI schema."""
+    app = Tooli(name="test-api")
+
+    @app.command()
+    def compute(x: int, y: int) -> int:
+        """Add two numbers."""
+        return x + y
+
+    client = TooliTestClient(app)
+    result = client.invoke(["api", "export-openapi"])
+    assert result.exit_code == 0
+    
+    schema = json.loads(result.output)
+    assert schema["openapi"] == "3.1.0"
+    assert "/compute" in schema["paths"]
+    assert "x" in schema["paths"]["/compute"]["post"]["requestBody"]["content"]["application/json"]["schema"]["properties"]

--- a/tooli/api/openapi.py
+++ b/tooli/api/openapi.py
@@ -1,0 +1,90 @@
+"""OpenAPI schema generation for Tooli apps."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from tooli.app import Tooli
+
+
+def generate_openapi_schema(app: Tooli) -> dict[str, Any]:
+    """Generate OpenAPI 3.1.0 schema for a Tooli application."""
+    from tooli.schema import generate_tool_schema
+
+    name = app.info.name or "tooli-app"
+    description = app.info.help or "An agent-native CLI application."
+    version = app.version or "0.0.0"
+
+    paths: dict[str, Any] = {}
+
+    for cmd in app.registered_commands:
+        if cmd.hidden:
+            continue
+
+        cmd_id = cmd.name or cmd.callback.__name__
+        schema = generate_tool_schema(cmd.callback, name=cmd_id)
+
+        # We model every command as a POST request to avoid URL length issues
+        # and to keep it simple for agent discovery.
+        paths[f"/{cmd_id}"] = {
+            "post": {
+                "summary": schema.description.split("\n")[0],
+                "description": schema.description,
+                "operationId": cmd_id,
+                "requestBody": {
+                    "content": {"application/json": {"schema": schema.input_schema}},
+                    "required": True,
+                },
+                "responses": {
+                    "200": {
+                        "description": "Successful response",
+                        "content": {
+                            "application/json": {
+                                "schema": {"$ref": "#/components/schemas/Envelope"}
+                            }
+                        },
+                    }
+                },
+                "tags": [name],
+            }
+        }
+
+    return {
+        "openapi": "3.1.0",
+        "info": {"title": name, "description": description, "version": version},
+        "paths": paths,
+        "components": {
+            "schemas": {
+                "Envelope": {
+                    "type": "object",
+                    "properties": {
+                        "ok": {"type": "boolean"},
+                        "result": {"type": "object", "nullable": True},
+                        "meta": {
+                            "type": "object",
+                            "properties": {
+                                "tool": {"type": "string"},
+                                "version": {"type": "string"},
+                                "duration_ms": {"type": "integer", "minimum": 0},
+                                "warnings": {"type": "array", "items": {"type": "string"}},
+                            },
+                            "required": ["tool", "version", "duration_ms", "warnings"],
+                        },
+                        "error": {
+                            "type": "object",
+                            "nullable": True,
+                            "properties": {
+                                "message": {"type": "string"},
+                                "code": {"type": "string"},
+                                "category": {"type": "string"},
+                                "suggestion": {"type": "object", "nullable": True},
+                                "details": {"type": "object"},
+                            },
+                        },
+                    },
+                    "required": ["ok", "meta"],
+                }
+            }
+        },
+    }

--- a/tooli/api/server.py
+++ b/tooli/api/server.py
@@ -1,0 +1,105 @@
+"""HTTP API server for Tooli apps."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from tooli.app import Tooli
+
+
+def build_app(app: Tooli) -> Any:
+    """Build a Starlette application for the Tooli app."""
+    try:
+        from starlette.applications import Starlette
+        from starlette.responses import JSONResponse
+        from starlette.routing import Route
+    except ImportError:
+        raise ImportError("Starlette is required for HTTP serving. Install it with 'pip install starlette'.")
+
+    from tooli.api.openapi import generate_openapi_schema
+
+    async def openapi_endpoint(request: Any) -> JSONResponse:
+        return JSONResponse(generate_openapi_schema(app))
+
+    routes = [
+        Route("/openapi.json", openapi_endpoint, methods=["GET"]),
+    ]
+
+    # Create an endpoint for each command
+    for cmd in app.registered_commands:
+        if cmd.hidden:
+            continue
+
+        cmd_id = cmd.name or cmd.callback.__name__
+
+        async def make_handler(command: Any) -> Any:
+            async def handler(request: Any) -> JSONResponse:
+                try:
+                    body = await request.json()
+                except Exception:
+                    body = {}
+                
+                # We need to invoke the command. 
+                # For simplicity in this implementation, we call the callback directly.
+                # In a real implementation, we'd want to handle Click context etc.
+                try:
+                    # Capture duration
+                    import time
+                    start = time.perf_counter()
+                    
+                    # Tooli commands usually return a value. 
+                    # If it's async, we await it.
+                    import inspect
+                    if inspect.iscoroutinefunction(command.callback):
+                        result = await command.callback(**body)
+                    else:
+                        result = command.callback(**body)
+                    
+                    duration_ms = int((time.perf_counter() - start) * 1000)
+                    
+                    # Wrap in envelope
+                    from tooli.envelope import Envelope, EnvelopeMeta
+                    meta = EnvelopeMeta(
+                        tool=command.name or command.callback.__name__,
+                        version=app.version or "0.0.0",
+                        duration_ms=duration_ms,
+                    )
+                    env = Envelope(ok=True, result=result, meta=meta)
+                    return JSONResponse(env.model_dump())
+                except Exception as e:
+                    # Handle errors
+                    from tooli.errors import ToolError, InternalError
+                    if not isinstance(e, ToolError):
+                        e = InternalError(message=str(e))
+                    
+                    from tooli.envelope import Envelope, EnvelopeMeta
+                    meta = EnvelopeMeta(
+                        tool=command.name or command.callback.__name__,
+                        version=app.version or "0.0.0",
+                        duration_ms=0,
+                    )
+                    env = Envelope(ok=False, result=None, meta=meta)
+                    out = env.model_dump()
+                    out["error"] = e.to_dict()
+                    return JSONResponse(out, status_code=getattr(e, "exit_code", 500))
+
+            return handler
+
+        routes.append(Route(f"/{cmd_id}", await make_handler(cmd), methods=["POST"]))
+
+    return Starlette(debug=True, routes=routes)
+
+
+def serve_api(app: Tooli, host: str = "localhost", port: int = 8000) -> None:
+    """Run the Tooli app as an HTTP API server."""
+    try:
+        import uvicorn
+    except ImportError:
+        print("Error: uvicorn is not installed. Install it with 'pip install uvicorn'.")
+        import sys
+        sys.exit(1)
+
+    starlette_app = build_app(app)
+    uvicorn.run(starlette_app, host=host, port=port)

--- a/tooli/app.py
+++ b/tooli/app.py
@@ -71,18 +71,20 @@ class Tooli(typer.Typer):
 
     def _register_builtins(self) -> None:
         @self.command(name="generate-skill", hidden=True)
-        def generate_skill() -> None:
+        def generate_skill(
+            output: str = typer.Option("SKILL.md", help="Output file path"),
+        ) -> None:
             """Generate SKILL.md for this application."""
             from tooli.docs.skill import generate_skill_md
+
             content = generate_skill_md(self)
-            with open("SKILL.md", "w") as f:
+            with open(output, "w") as f:
                 f.write(content)
-            # Use click.echo as we are in a CLI context
             import click
-            click.echo("Generated SKILL.md")
+
+            click.echo(f"Generated {output}")
 
         # MCP group
-        import typer
         mcp_app = typer.Typer(name="mcp", help="MCP server utilities", hidden=True)
         self.add_typer(mcp_app)
 
@@ -92,6 +94,7 @@ class Tooli(typer.Typer):
             from tooli.mcp.export import export_mcp_tools
             import json
             import click
+
             tools = export_mcp_tools(self)
             click.echo(json.dumps(tools, indent=2))
 
@@ -103,6 +106,7 @@ class Tooli(typer.Typer):
         ) -> None:
             """Run the application as an MCP server."""
             from tooli.mcp.server import serve_mcp
+
             serve_mcp(self, transport=transport, host=host, port=port)
 
         # Docs group
@@ -120,6 +124,7 @@ class Tooli(typer.Typer):
                 f.write(generate_llms_full_txt(self))
 
             import click
+
             click.echo("Generated llms.txt and llms-full.txt")
 
         @docs_app.command(name="man")
@@ -134,7 +139,32 @@ class Tooli(typer.Typer):
                 f.write(content)
 
             import click
+
             click.echo(f"Generated {filename}")
+
+        # API group
+        api_app = typer.Typer(name="api", help="HTTP API utilities", hidden=True)
+        self.add_typer(api_app)
+
+        @api_app.command(name="export-openapi")
+        def api_export_openapi() -> None:
+            """Export OpenAPI 3.1.0 schema as JSON."""
+            from tooli.api.openapi import generate_openapi_schema
+            import json
+            import click
+
+            schema = generate_openapi_schema(self)
+            click.echo(json.dumps(schema, indent=2))
+
+        @api_app.command(name="serve")
+        def api_serve(
+            host: str = typer.Option("localhost", help="HTTP host"),
+            port: int = typer.Option(8000, help="HTTP port"),
+        ) -> None:
+            """Run the application as an HTTP API server."""
+            from tooli.api.server import serve_api
+
+            serve_api(self, host=host, port=port)
 
         # Eval utilities
         eval_app = typer.Typer(name="eval", help="Evaluation tooling")

--- a/tooli/command_meta.py
+++ b/tooli/command_meta.py
@@ -1,0 +1,53 @@
+"""Metadata container for Tooli command callbacks."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Callable
+
+from tooli.annotations import ToolAnnotation
+from tooli.auth import AuthContext
+from tooli.security.policy import SecurityPolicy
+
+
+@dataclass
+class CommandMeta:
+    """All Tooli metadata for a registered command callback.
+
+    Attached as a single ``__tooli_meta__`` attribute on the callback
+    function, replacing the previous 20+ individual ``setattr`` calls.
+    """
+
+    # App-level
+    app_name: str = "tooli"
+    app_version: str = "0.0.0"
+    default_output: str = "auto"
+    telemetry_pipeline: Any = None
+    invocation_recorder: Any = None
+    security_policy: SecurityPolicy = SecurityPolicy.OFF
+    auth_context: AuthContext | None = None
+
+    # Command-level
+    annotations: ToolAnnotation | None = None
+    examples: list[dict[str, Any]] = field(default_factory=list)
+    error_codes: dict[str, str] = field(default_factory=dict)
+    timeout: float | None = None
+    cost_hint: str | None = None
+    human_in_the_loop: bool = False
+    auth: list[str] = field(default_factory=list)
+    list_processing: bool = False
+    paginated: bool = False
+    version: str | None = None
+    deprecated: bool = False
+    deprecated_message: str | None = None
+    secret_params: list[str] = field(default_factory=list)
+
+
+def get_command_meta(callback: Callable[..., Any] | None) -> CommandMeta:
+    """Retrieve CommandMeta from a callback, with safe defaults."""
+    if callback is None:
+        return CommandMeta()
+    meta = getattr(callback, "__tooli_meta__", None)
+    if isinstance(meta, CommandMeta):
+        return meta
+    return CommandMeta()


### PR DESCRIPTION
This PR adds support for serving Tooli apps as HTTP APIs with OpenAPI schemas and enables non-stdio MCP transports.