### PR TITLE
Add PyPI publishing readiness files

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,25 @@
+---
+name: Bug Report
+about: Report a bug in tooli
+title: ""
+labels: bug
+assignees: ""
+---
+
+**Describe the bug**
+A clear description of what the bug is.
+
+**To Reproduce**
+Steps or minimal code to reproduce:
+
+```python
+# Your code here
+```
+
+**Expected behavior**
+What you expected to happen.
+
+**Environment**
+- Python version:
+- tooli version:
+- OS:

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,16 @@
+---
+name: Feature Request
+about: Suggest a new feature
+title: ""
+labels: enhancement
+assignees: ""
+---
+
+**What problem does this solve?**
+A clear description of the problem or use case.
+
+**Proposed solution**
+How you'd like it to work.
+
+**Alternatives considered**
+Any other approaches you've thought about.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,61 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.12"
+    - name: Install build tools
+      run: python -m pip install --upgrade pip build twine
+    - name: Build
+      run: python -m build
+    - name: Check distribution
+      run: python -m twine check dist/*
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: dist
+        path: dist/
+
+  publish-testpypi:
+    needs: build
+    runs-on: ubuntu-latest
+    environment: testpypi
+    permissions:
+      id-token: write
+    steps:
+    - name: Download artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: dist
+        path: dist/
+    - name: Publish to TestPyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        repository-url: https://test.pypi.org/legacy/
+
+  publish-pypi:
+    needs: publish-testpypi
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+    - name: Download artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: dist
+        path: dist/
+    - name: Publish to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,8 @@ share/python-wheels/
 .installed.cfg
 *.egg
 MANIFEST
+pypichecklist.md
+pypi/
 
 # PyInstaller
 *.manifest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,31 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.0.0] - 2026-02-15
+
+### Added
+- Core framework: `Tooli` class extending Typer with agent-native defaults
+- Output modes: AUTO, JSON, JSONL, TEXT, PLAIN with `--output` flag
+- Structured error hierarchy: InputError, AuthError, StateError, ToolRuntimeError, InternalError
+- Annotations: ReadOnly, Destructive, Idempotent, OpenWorld (composable with `|`)
+- Cursor-based pagination with `--limit`, `--cursor`, `--fields`, `--filter`
+- `StdinOr[T]` for unified input from files, URLs, and stdin
+- `SecretInput[T]` with automatic redaction in output and error messages
+- `@dry_run_support` decorator with `record_dry_action()` for previewing side effects
+- Process-local idempotency tracking with key support
+- MCP server support (stdio, HTTP, SSE) via `tooli[mcp]`
+- HTTP API server with OpenAPI 3.1 schema generation via `tooli[api]` (experimental)
+- Auth context framework with scope-based access control
+- Security policy (OFF, STANDARD, STRICT) with output sanitization
+- Opt-in telemetry pipeline with local-first storage and configurable retention
+- Invocation recording and analysis for eval workflows
+- Transform pipeline: NamespaceTransform, VisibilityTransform
+- Versioned commands with automatic `-v{X}` suffix handling
+- Documentation generation: SKILL.md, llms.txt, Unix man pages
+- 9 example apps: note_indexer, docq, gitsum, csvkit_t, syswatch, taskr, proj, envar, imgsort
+
+[1.0.0]: https://github.com/weisberg/tooli/releases/tag/v1.0.0

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,38 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+
+Examples of unacceptable behavior:
+
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information without explicit permission
+* Other conduct which could reasonably be considered inappropriate
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the project maintainers. All complaints will be reviewed and
+investigated and will result in a response that is deemed necessary and
+appropriate to the circumstances.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org),
+version 2.0.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,56 @@
+# Contributing to Tooli
+
+Thank you for your interest in contributing to Tooli!
+
+## Getting Started
+
+1. Fork the repository and clone your fork
+2. Create a virtual environment and install dev dependencies:
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate
+   pip install -e ".[dev]"
+   ```
+3. Create a branch for your change:
+   ```bash
+   git checkout -b my-feature
+   ```
+
+## Development Workflow
+
+### Running Tests
+
+```bash
+pytest
+```
+
+### Linting and Type Checking
+
+```bash
+ruff check .
+mypy tooli
+```
+
+### Code Style
+
+- We use **ruff** for linting and import sorting
+- We use **mypy** in strict mode for type checking
+- All public functions should have type annotations
+- Follow existing patterns in the codebase
+
+## Pull Requests
+
+1. Ensure all tests pass and linting is clean
+2. Write tests for new functionality
+3. Keep PRs focused — one feature or fix per PR
+4. Write a clear description of what changed and why
+
+## Reporting Issues
+
+- Use [GitHub Issues](https://github.com/weisberg/tooli/issues)
+- Include a minimal reproducible example when possible
+- Specify your Python version and tooli version
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the MIT License.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "typer>=0.9",
     "pydantic>=2.0",
     "rich>=13.0",
+    "tomli>=2.0; python_version < '3.11'",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
- Added `CHANGELOG.md`, `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`
- Added GitHub Actions publish workflow (build → TestPyPI → PyPI via OIDC trusted publishing)
- Added issue templates for bug reports and feature requests
- Added `tomli` dependency for Python 3.10 compatibility

## Remaining PyPI steps (manual)
1. **TestPyPI dry run** — Create a GitHub Release to trigger the workflow, or upload manually with `twine`
2. **Configure trusted publisher** — Set up `testpypi` and `pypi` environments in GitHub repo settings with OIDC

## Test plan
- [x] All 147 tests pass
- [x] Ruff lint clean
- [ ] CI passes on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)