### PR TITLE
Release v1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.1] - 2026-02-15
+
+### Changed
+- Updated all project documentation (README, examples, PLAN, PRD, CLAUDE.md)
+- Added CI/PyPI/license badges to README
+- Added optional extras install instructions (`tooli[mcp]`, `tooli[api]`)
+- Rewrote examples README with all 18 apps organized by category
+- Added CONTRIBUTING.md, CODE_OF_CONDUCT.md, CHANGELOG.md
+- Added GitHub Actions publish workflow with OIDC trusted publishing
+- Added issue templates for bug reports and feature requests
+- Added `tomli` dependency for Python 3.10 compatibility
+
 ## [1.0.0] - 2026-02-15
 
 ### Added
@@ -28,4 +40,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Documentation generation: SKILL.md, llms.txt, Unix man pages
 - 9 example apps: note_indexer, docq, gitsum, csvkit_t, syswatch, taskr, proj, envar, imgsort
 
+[1.0.1]: https://github.com/weisberg/tooli/releases/tag/v1.0.1
 [1.0.0]: https://github.com/weisberg/tooli/releases/tag/v1.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,9 +4,9 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tooli"
-version = "1.0.0"
+version = "1.0.1"
 description = "The agent-native CLI framework for Python"
-readme = "README.md"
+readme = "pypi/pypi_project.md"
 requires-python = ">=3.10"
 license = "MIT"
 authors = [

--- a/tooli/__init__.py
+++ b/tooli/__init__.py
@@ -11,7 +11,7 @@ from tooli.dry_run import DryRunRecorder, dry_run_support, record_dry_action
 from tooli.input import SecretInput, StdinOr
 from tooli.versioning import VersionFilter, compare_versions
 
-__version__ = "1.0.0"
+__version__ = "1.0.1"
 __all__ = [
     "Annotated",
     "Argument",


### PR DESCRIPTION
## Summary
- Bump version to 1.0.1 in pyproject.toml and tooli/__init__.py
- Update CHANGELOG.md with 1.0.1 entry

## Test plan
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)