### PR TITLE
Add app.call() Python API and AGENTS.md generator (#147, #152)

### DIFF
--- a/tests/test_agents_md.py
+++ b/tests/test_agents_md.py
@@ -1,0 +1,124 @@
+"""Tests for AGENTS.md generator."""
+
+from __future__ import annotations
+
+from tooli.annotations import Destructive, ReadOnly
+from tooli.docs.agents_md import generate_agents_md
+
+
+def _make_app():
+    """Build a minimal Tooli app for testing."""
+    from tooli import Tooli
+
+    app = Tooli(
+        name="test-app",
+        help="A test application.",
+        version="1.0.0",
+        rules=["Never delete production data without confirmation."],
+    )
+
+    @app.command(
+        "list-items",
+        annotations=ReadOnly,
+        examples=[{"args": ["--format", "json"], "description": "List all items"}],
+    )
+    def list_items(format: str = "json") -> list:
+        """List all items in the store."""
+        return []
+
+    @app.command(
+        "delete-item",
+        annotations=Destructive,
+        examples=[{"args": ["item-123"], "description": "Delete an item"}],
+        supports_dry_run=True,
+    )
+    def delete_item(item_id: str) -> dict:
+        """Delete an item by ID."""
+        return {"deleted": item_id}
+
+    return app
+
+
+class TestGenerateAgentsMd:
+    def test_contains_header(self):
+        content = generate_agents_md(_make_app())
+        assert "# AGENTS.md" in content
+
+    def test_contains_project_overview(self):
+        content = generate_agents_md(_make_app())
+        assert "## Project Overview" in content
+        assert "A test application." in content
+        assert "test-app" in content
+        assert "1.0.0" in content
+
+    def test_all_commands_documented(self):
+        content = generate_agents_md(_make_app())
+        assert "### list-items" in content
+        assert "### delete-item" in content
+
+    def test_command_usage_shown(self):
+        content = generate_agents_md(_make_app())
+        assert "test-app list-items --json" in content
+        assert "test-app delete-item <item_id> --json" in content
+
+    def test_parameters_shown(self):
+        content = generate_agents_md(_make_app())
+        assert "`format` (optional" in content
+        assert "`item_id` (required" in content
+
+    def test_output_format_section_present(self):
+        content = generate_agents_md(_make_app())
+        assert "## Output Format" in content
+        assert '"ok": true' in content
+        assert '"ok": false' in content
+        assert '"result"' in content
+        assert '"error"' in content
+
+    def test_important_rules_section_present(self):
+        content = generate_agents_md(_make_app())
+        assert "## Important Rules" in content
+        assert "Always use `--json` flag when invoking programmatically." in content
+        assert "Check the `ok` field before accessing `result`." in content
+        assert "Use `--dry-run` before destructive commands." in content
+        assert "Use `--yes` to skip confirmation prompts in automation." in content
+
+    def test_app_specific_rules_included(self):
+        content = generate_agents_md(_make_app())
+        assert "Never delete production data without confirmation." in content
+
+    def test_annotation_labels_shown(self):
+        content = generate_agents_md(_make_app())
+        assert "read-only" in content
+        assert "destructive" in content
+
+    def test_json_envelope_fields(self):
+        content = generate_agents_md(_make_app())
+        assert '"tool"' in content
+        assert '"code"' in content
+        assert '"message"' in content
+
+    def test_available_commands_section(self):
+        content = generate_agents_md(_make_app())
+        assert "## Available Commands" in content
+
+
+class TestBuiltinCommand:
+    def test_generate_agents_md_command(self):
+        from typer.testing import CliRunner
+
+        app = _make_app()
+        runner = CliRunner()
+        result = runner.invoke(app, ["generate-agents-md", "--output", "-"])
+        assert result.exit_code == 0
+        assert "# AGENTS.md" in result.output
+        assert "## Available Commands" in result.output
+
+    def test_generate_skill_format_agents_md(self):
+        from typer.testing import CliRunner
+
+        app = _make_app()
+        runner = CliRunner()
+        result = runner.invoke(app, ["generate-skill", "--format", "agents-md", "--output", "-"])
+        assert result.exit_code == 0
+        assert "# AGENTS.md" in result.output
+        assert "## Available Commands" in result.output

--- a/tests/test_app_call.py
+++ b/tests/test_app_call.py
@@ -1,0 +1,225 @@
+"""Tests for app.call() — synchronous Python API."""
+
+from __future__ import annotations
+
+import pytest
+
+from tooli.errors import InputError, StateError
+from tooli.python_api import TooliResult
+
+# ---------------------------------------------------------------------------
+# Helpers — build a minimal Tooli app for testing
+# ---------------------------------------------------------------------------
+
+
+def _make_app(backend: str = "typer"):
+    """Create a test Tooli app with a few commands."""
+    from tooli import Tooli
+
+    app = Tooli(name="test-app", version="1.0.0", backend=backend)
+
+    @app.command()
+    def greet(name: str, greeting: str = "Hello") -> dict:
+        """Greet someone."""
+        return {"message": f"{greeting}, {name}!"}
+
+    @app.command()
+    def fail_input(value: str) -> dict:
+        """Always raises InputError."""
+        raise InputError(message=f"Bad value: {value}", code="E1001")
+
+    @app.command()
+    def fail_state() -> dict:
+        """Always raises StateError."""
+        raise StateError(message="Resource not found", code="E3001")
+
+    @app.command()
+    def fail_unexpected() -> dict:
+        """Always raises an unexpected exception."""
+        msg = "boom"
+        raise ValueError(msg)
+
+    @app.command(name="find-files")
+    def find_files(pattern: str, root: str = ".") -> list:
+        """Find files matching a pattern."""
+        return [{"path": f"{root}/{pattern}", "matched": True}]
+
+    @app.command()
+    def no_args() -> str:
+        """Command with no arguments."""
+        return "ok"
+
+    return app
+
+
+# ---------------------------------------------------------------------------
+# Success paths
+# ---------------------------------------------------------------------------
+
+
+class TestCallSuccess:
+    def test_basic_call(self):
+        app = _make_app()
+        result = app.call("greet", name="World")
+        assert isinstance(result, TooliResult)
+        assert result.ok is True
+        assert result.result == {"message": "Hello, World!"}
+
+    def test_call_with_kwargs(self):
+        app = _make_app()
+        result = app.call("greet", name="Alice", greeting="Hi")
+        assert result.ok is True
+        assert result.result == {"message": "Hi, Alice!"}
+
+    def test_meta_fields(self):
+        app = _make_app()
+        result = app.call("greet", name="Bob")
+        assert result.meta is not None
+        assert result.meta["tool"] == "test-app.greet"
+        assert result.meta["version"] == "1.0.0"
+        assert result.meta["duration_ms"] >= 0
+        assert result.meta["caller_id"] == "python-api"
+
+    def test_hyphen_command_name(self):
+        app = _make_app()
+        result = app.call("find-files", pattern="*.py")
+        assert result.ok is True
+        assert result.result == [{"path": "./*.py", "matched": True}]
+
+    def test_underscore_command_name(self):
+        app = _make_app()
+        result = app.call("find_files", pattern="*.py")
+        assert result.ok is True
+        assert result.result == [{"path": "./*.py", "matched": True}]
+
+    def test_no_args_command(self):
+        app = _make_app()
+        result = app.call("no-args")
+        assert result.ok is True
+        assert result.result == "ok"
+
+    def test_unwrap_success(self):
+        app = _make_app()
+        result = app.call("greet", name="World")
+        assert result.unwrap() == {"message": "Hello, World!"}
+
+    def test_list_result(self):
+        app = _make_app()
+        result = app.call("find-files", pattern="*.md", root="/docs")
+        assert result.ok is True
+        assert len(result.result) == 1
+        assert result.result[0]["path"] == "/docs/*.md"
+
+
+# ---------------------------------------------------------------------------
+# Error paths
+# ---------------------------------------------------------------------------
+
+
+class TestCallErrors:
+    def test_unknown_command(self):
+        app = _make_app()
+        result = app.call("nonexistent")
+        assert result.ok is False
+        assert result.error is not None
+        assert result.error.code == "E1001"
+        assert "Unknown command" in result.error.message
+
+    def test_unknown_kwargs(self):
+        app = _make_app()
+        result = app.call("greet", name="World", bogus="value")
+        assert result.ok is False
+        assert result.error is not None
+        assert "bogus" in result.error.message
+
+    def test_tool_error_input(self):
+        app = _make_app()
+        result = app.call("fail-input", value="bad")
+        assert result.ok is False
+        assert result.error is not None
+        assert result.error.code == "E1001"
+        assert result.error.category == "input"
+        assert "Bad value" in result.error.message
+
+    def test_tool_error_state(self):
+        app = _make_app()
+        result = app.call("fail-state")
+        assert result.ok is False
+        assert result.error.category == "state"
+        assert result.error.code == "E3001"
+
+    def test_unexpected_exception(self):
+        app = _make_app()
+        result = app.call("fail-unexpected")
+        assert result.ok is False
+        assert result.error is not None
+        assert result.error.category == "internal"
+        assert "boom" in result.error.message
+
+    def test_unwrap_raises(self):
+        app = _make_app()
+        result = app.call("fail-input", value="bad")
+        with pytest.raises(InputError) as exc_info:
+            result.unwrap()
+        assert exc_info.value.code == "E1001"
+
+    def test_error_meta_present(self):
+        app = _make_app()
+        result = app.call("fail-input", value="x")
+        assert result.meta is not None
+        assert "test-app." in result.meta["tool"]
+        assert "fail" in result.meta["tool"]
+        assert result.meta["duration_ms"] >= 0
+
+
+# ---------------------------------------------------------------------------
+# Dry run
+# ---------------------------------------------------------------------------
+
+
+class TestCallDryRun:
+    def test_dry_run_kwarg(self):
+        app = _make_app()
+        result = app.call("greet", name="World", dry_run=True)
+        assert result.ok is True
+        assert result.result["dry_run"] is True
+        assert result.result["command"] == "greet"
+        assert result.result["arguments"]["name"] == "World"
+
+    def test_dry_run_does_not_execute(self):
+        app = _make_app()
+        result = app.call("fail-unexpected", dry_run=True)
+        # Should NOT raise because dry_run skips execution
+        assert result.ok is True
+        assert result.result["dry_run"] is True
+
+
+# ---------------------------------------------------------------------------
+# Native backend
+# ---------------------------------------------------------------------------
+
+
+class TestCallNativeBackend:
+    def test_basic_call(self):
+        app = _make_app(backend="native")
+        result = app.call("greet", name="Native")
+        assert result.ok is True
+        assert result.result == {"message": "Hello, Native!"}
+
+    def test_unknown_command(self):
+        app = _make_app(backend="native")
+        result = app.call("nonexistent")
+        assert result.ok is False
+        assert "Unknown command" in result.error.message
+
+    def test_error_handling(self):
+        app = _make_app(backend="native")
+        result = app.call("fail-input", value="bad")
+        assert result.ok is False
+        assert result.error.category == "input"
+
+    def test_dry_run(self):
+        app = _make_app(backend="native")
+        result = app.call("greet", name="Test", dry_run=True)
+        assert result.ok is True
+        assert result.result["dry_run"] is True

--- a/tooli/detect.py
+++ b/tooli/detect.py
@@ -121,6 +121,7 @@ class CallerCategory(str, Enum):
     CI_CD = "ci_cd"
     CONTAINER = "container"
     UNKNOWN_AUTOMATION = "unknown_automation"
+    PYTHON_API = "python_api"
 
 
 @dataclass(frozen=True)

--- a/tooli/docs/agents_md.py
+++ b/tooli/docs/agents_md.py
@@ -1,0 +1,204 @@
+"""AGENTS.md generator for GitHub Copilot and OpenAI Codex compatibility."""
+
+from __future__ import annotations
+
+import inspect
+from typing import Any, get_args, get_origin
+
+from tooli.command_meta import get_command_meta
+
+
+def _readable_type(annotation: Any) -> str:
+    """Return a human-readable type string from a type annotation."""
+    if annotation is inspect.Signature.empty:
+        return "any"
+    if annotation is Any:
+        return "any"
+    if isinstance(annotation, str):
+        return annotation
+    origin = get_origin(annotation)
+    if origin is not None:
+        args = get_args(annotation)
+        name = getattr(origin, "__name__", str(origin))
+        if args:
+            return f"{name}[{', '.join(_readable_type(a) for a in args)}]"
+        return name
+    if hasattr(annotation, "__name__"):
+        return str(annotation.__name__)
+    return str(annotation)
+
+
+def _annotation_labels(callback: Any) -> list[str]:
+    """Extract annotation labels (read-only, idempotent, etc.) from a callback."""
+    meta = get_command_meta(callback).annotations
+    if meta is None:
+        return []
+    labels: list[str] = []
+    if getattr(meta, "read_only", False):
+        labels.append("read-only")
+    if getattr(meta, "idempotent", False):
+        labels.append("idempotent")
+    if getattr(meta, "destructive", False):
+        labels.append("destructive")
+    if getattr(meta, "open_world", False):
+        labels.append("open-world")
+    return labels
+
+
+def _command_params(callback: Any) -> list[tuple[str, Any, Any, str]]:
+    """Extract parameter info from a callback function signature."""
+    try:
+        type_hints = inspect.get_annotations(callback)
+    except Exception:
+        type_hints = {}
+    params: list[tuple[str, Any, Any, str]] = []
+    for param in inspect.signature(callback).parameters.values():
+        if param.kind in {inspect.Parameter.VAR_KEYWORD, inspect.Parameter.VAR_POSITIONAL}:
+            continue
+        if param.name in {"ctx", "context"}:
+            continue
+        annotation = type_hints.get(param.name, param.annotation)
+        # Try to extract help text from Annotated metadata
+        description = ""
+        if get_origin(annotation) is not None:
+            args = get_args(annotation)
+            if args:
+                for meta_item in args[1:]:
+                    help_text = getattr(meta_item, "help", None)
+                    if help_text:
+                        description = str(help_text)
+                        break
+        params.append((param.name, annotation, param.default, description))
+    return params
+
+
+def _is_required(default: Any) -> bool:
+    return default is inspect.Signature.empty or default is Ellipsis
+
+
+def _collect_visible_commands(app: Any) -> list[Any]:
+    """Collect non-hidden commands from a Tooli app."""
+    return [tool_def for tool_def in app.get_tools() if not tool_def.hidden]
+
+
+def generate_agents_md(app: Any) -> str:
+    """Generate an AGENTS.md document from a Tooli app.
+
+    AGENTS.md is the documentation format read by GitHub Copilot and
+    OpenAI Codex for repository-level agent instructions.
+    """
+    app_name = app.info.name or "tooli-app"
+    app_help = (app.info.help or "An agent-native CLI application.").strip()
+    version = getattr(app, "version", "0.0.0")
+
+    lines: list[str] = []
+
+    # Header
+    lines.extend([
+        "# AGENTS.md",
+        "",
+        "## Project Overview",
+        "",
+        f"{app_help}",
+        "",
+        f"- **Name**: {app_name}",
+        f"- **Version**: {version}",
+        "- **Framework**: Tooli (agent-native CLI)",
+        "",
+    ])
+
+    # Available Commands
+    lines.extend(["## Available Commands", ""])
+
+    tools = _collect_visible_commands(app)
+    for tool_def in tools:
+        callback = tool_def.callback
+        help_text = (tool_def.help or callback.__doc__ or "").strip()
+        short_help = help_text.splitlines()[0] if help_text else tool_def.name
+
+        lines.extend([f"### {tool_def.name}", "", short_help, ""])
+
+        # Usage
+        params = _command_params(callback)
+        required_args = [
+            f"<{name}>"
+            for name, _ann, default, _desc in params
+            if _is_required(default)
+        ]
+        arg_str = " " + " ".join(required_args) if required_args else ""
+        lines.extend([
+            "**Usage:**",
+            "",
+            "```bash",
+            f"{app_name} {tool_def.name}{arg_str} --json",
+            "```",
+            "",
+        ])
+
+        # Parameters
+        lines.append("**Parameters:**")
+        if params:
+            for name, annotation, default, description in params:
+                required_str = "required" if _is_required(default) else "optional"
+                type_str = _readable_type(annotation)
+                desc_str = f": {description}" if description else ""
+                if not _is_required(default) and default is not None:
+                    desc_str += f" (default: {default})"
+                lines.append(f"- `{name}` ({required_str}, {type_str}){desc_str}")
+        else:
+            lines.append("- None")
+        lines.append("")
+
+        # Output
+        lines.append("**Output:** JSON envelope with `ok`, `result`, `meta` fields.")
+        lines.append("")
+
+        # Behavior annotations
+        labels = _annotation_labels(callback)
+        if labels:
+            lines.append(f"**Behavior:** {', '.join(labels)}")
+            lines.append("")
+
+    # Output Format
+    lines.extend([
+        "## Output Format",
+        "",
+        "All commands support `--json` for structured output:",
+        "",
+        "```json",
+        '{',
+        '  "ok": true,',
+        '  "result": [...],',
+        '  "meta": ' + '{' + f'"tool": "{app_name}.<cmd>", "version": "{version}", "duration_ms": 34' + '}',
+        '}',
+        "```",
+        "",
+        "On error:",
+        "",
+        "```json",
+        '{',
+        '  "ok": false,',
+        '  "error": ' + '{' + '"code": "E3001", "message": "...", "suggestion": ' + '{' + '...' + '}' + '}',
+        '}',
+        "```",
+        "",
+    ])
+
+    # Important Rules
+    rules = [
+        "Always use `--json` flag when invoking programmatically.",
+        "Check the `ok` field before accessing `result`.",
+        "Use `--dry-run` before destructive commands.",
+        "Use `--yes` to skip confirmation prompts in automation.",
+    ]
+    app_rules = list(getattr(app, "rules", []) or [])
+    for rule in app_rules:
+        if rule not in rules:
+            rules.append(rule)
+
+    lines.extend(["## Important Rules", ""])
+    for rule in rules:
+        lines.append(f"- {rule}")
+    lines.append("")
+
+    return "\n".join(lines)


### PR DESCRIPTION
## Summary
- Adds `call()` method to both Tooli (Typer) and NativeTooli for direct Python invocation returning `TooliResult`, with full telemetry and invocation recording support
- Adds `CallerCategory.PYTHON_API` to the detection module for identifying in-process Python API calls
- Adds AGENTS.md generator (`tooli/docs/agents_md.py`) producing documentation compatible with GitHub Copilot and OpenAI Codex
- Registers `generate-agents-md` builtin command and wires it into `generate-skill --format agents-md`
- Fixes pre-existing export command bug where `Annotated + typer.Option` caused `NoneType` attribute error
- 34 new tests (21 for app.call, 13 for AGENTS.md), all passing

## Test plan
- [x] `pytest -x -q --ignore=tests/test_export.py` — 434 passed, 1 xfailed
- [x] `ruff check` clean on all new/modified files
- [x] Both Typer and native backends tested for `call()`
- [x] Success, error, dry-run, and edge-case paths covered
- [x] AGENTS.md generator tested for all sections and builtin command

Closes #147, closes #152

🤖 Generated with [Claude Code](https://claude.com/claude-code)