### PR TITLE
Add acall(), get_command(), and Python API tests (#148-#151)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,3 +74,4 @@ disallow_untyped_defs = true
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 addopts = "-v --tb=short"
+asyncio_mode = "auto"

--- a/tests/test_app_acall.py
+++ b/tests/test_app_acall.py
@@ -1,0 +1,224 @@
+"""Tests for app.acall() — async Python API."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from tooli.errors import InputError
+from tooli.python_api import TooliResult
+
+# ---------------------------------------------------------------------------
+# Helpers — build a minimal Tooli app for testing
+# ---------------------------------------------------------------------------
+
+
+def _make_app(backend: str = "typer"):
+    """Create a test Tooli app with sync and async commands."""
+    from tooli import Tooli
+
+    app = Tooli(name="test-app", version="1.0.0", backend=backend)
+
+    @app.command()
+    def greet(name: str, greeting: str = "Hello") -> dict:
+        """Greet someone (sync)."""
+        return {"message": f"{greeting}, {name}!"}
+
+    @app.command()
+    async def greet_async(name: str, greeting: str = "Hello") -> dict:
+        """Greet someone (async)."""
+        await asyncio.sleep(0)  # yield to event loop
+        return {"message": f"{greeting}, {name}!"}
+
+    @app.command()
+    def fail_input(value: str) -> dict:
+        """Always raises InputError."""
+        raise InputError(message=f"Bad value: {value}", code="E1001")
+
+    @app.command()
+    async def fail_async() -> dict:
+        """Async command that raises."""
+        await asyncio.sleep(0)
+        msg = "async boom"
+        raise ValueError(msg)
+
+    @app.command(name="find-files")
+    def find_files(pattern: str, root: str = ".") -> list:
+        """Find files matching a pattern."""
+        return [{"path": f"{root}/{pattern}", "matched": True}]
+
+    @app.command()
+    def no_args() -> str:
+        """Command with no arguments."""
+        return "ok"
+
+    return app
+
+
+# ---------------------------------------------------------------------------
+# Async success paths
+# ---------------------------------------------------------------------------
+
+
+class TestAcallSuccess:
+    @pytest.mark.asyncio
+    async def test_sync_command_via_acall(self):
+        app = _make_app()
+        result = await app.acall("greet", name="World")
+        assert isinstance(result, TooliResult)
+        assert result.ok is True
+        assert result.result == {"message": "Hello, World!"}
+
+    @pytest.mark.asyncio
+    async def test_async_command_via_acall(self):
+        app = _make_app()
+        result = await app.acall("greet-async", name="World")
+        assert result.ok is True
+        assert result.result == {"message": "Hello, World!"}
+
+    @pytest.mark.asyncio
+    async def test_async_command_with_kwargs(self):
+        app = _make_app()
+        result = await app.acall("greet-async", name="Alice", greeting="Hi")
+        assert result.ok is True
+        assert result.result == {"message": "Hi, Alice!"}
+
+    @pytest.mark.asyncio
+    async def test_meta_fields(self):
+        app = _make_app()
+        result = await app.acall("greet", name="Bob")
+        assert result.meta is not None
+        assert "test-app." in result.meta["tool"]
+        assert result.meta["version"] == "1.0.0"
+        assert result.meta["duration_ms"] >= 0
+        assert result.meta["caller_id"] == "python-api"
+
+    @pytest.mark.asyncio
+    async def test_hyphen_command_name(self):
+        app = _make_app()
+        result = await app.acall("find-files", pattern="*.py")
+        assert result.ok is True
+
+    @pytest.mark.asyncio
+    async def test_underscore_command_name(self):
+        app = _make_app()
+        result = await app.acall("find_files", pattern="*.py")
+        assert result.ok is True
+
+    @pytest.mark.asyncio
+    async def test_no_args_command(self):
+        app = _make_app()
+        result = await app.acall("no-args")
+        assert result.ok is True
+        assert result.result == "ok"
+
+    @pytest.mark.asyncio
+    async def test_unwrap_success(self):
+        app = _make_app()
+        result = await app.acall("greet-async", name="World")
+        assert result.unwrap() == {"message": "Hello, World!"}
+
+
+# ---------------------------------------------------------------------------
+# Async error paths
+# ---------------------------------------------------------------------------
+
+
+class TestAcallErrors:
+    @pytest.mark.asyncio
+    async def test_unknown_command(self):
+        app = _make_app()
+        result = await app.acall("nonexistent")
+        assert result.ok is False
+        assert "Unknown command" in result.error.message
+
+    @pytest.mark.asyncio
+    async def test_unknown_kwargs(self):
+        app = _make_app()
+        result = await app.acall("greet", name="World", bogus="value")
+        assert result.ok is False
+        assert "bogus" in result.error.message
+
+    @pytest.mark.asyncio
+    async def test_sync_error_via_acall(self):
+        app = _make_app()
+        result = await app.acall("fail-input", value="bad")
+        assert result.ok is False
+        assert result.error.category == "input"
+
+    @pytest.mark.asyncio
+    async def test_async_unexpected_error(self):
+        app = _make_app()
+        result = await app.acall("fail-async")
+        assert result.ok is False
+        assert result.error.category == "internal"
+        assert "async boom" in result.error.message
+
+    @pytest.mark.asyncio
+    async def test_unwrap_raises(self):
+        app = _make_app()
+        result = await app.acall("fail-input", value="bad")
+        with pytest.raises(InputError):
+            result.unwrap()
+
+
+# ---------------------------------------------------------------------------
+# Async dry run
+# ---------------------------------------------------------------------------
+
+
+class TestAcallDryRun:
+    @pytest.mark.asyncio
+    async def test_dry_run_sync_command(self):
+        app = _make_app()
+        result = await app.acall("greet", name="World", dry_run=True)
+        assert result.ok is True
+        assert result.result["dry_run"] is True
+
+    @pytest.mark.asyncio
+    async def test_dry_run_async_command(self):
+        app = _make_app()
+        result = await app.acall("greet-async", name="World", dry_run=True)
+        assert result.ok is True
+        assert result.result["dry_run"] is True
+
+    @pytest.mark.asyncio
+    async def test_dry_run_does_not_execute(self):
+        app = _make_app()
+        result = await app.acall("fail-async", dry_run=True)
+        assert result.ok is True
+
+
+# ---------------------------------------------------------------------------
+# Native backend
+# ---------------------------------------------------------------------------
+
+
+class TestAcallNativeBackend:
+    @pytest.mark.asyncio
+    async def test_sync_command(self):
+        app = _make_app(backend="native")
+        result = await app.acall("greet", name="Native")
+        assert result.ok is True
+        assert result.result == {"message": "Hello, Native!"}
+
+    @pytest.mark.asyncio
+    async def test_async_command(self):
+        app = _make_app(backend="native")
+        result = await app.acall("greet-async", name="Native")
+        assert result.ok is True
+        assert result.result == {"message": "Hello, Native!"}
+
+    @pytest.mark.asyncio
+    async def test_unknown_command(self):
+        app = _make_app(backend="native")
+        result = await app.acall("nonexistent")
+        assert result.ok is False
+
+    @pytest.mark.asyncio
+    async def test_dry_run(self):
+        app = _make_app(backend="native")
+        result = await app.acall("greet-async", name="Test", dry_run=True)
+        assert result.ok is True
+        assert result.result["dry_run"] is True

--- a/tests/test_command_accessors.py
+++ b/tests/test_command_accessors.py
@@ -1,0 +1,136 @@
+"""Tests for command accessor methods (#149) and CallerCategory.PYTHON_API (#150)."""
+
+from __future__ import annotations
+
+from tooli.detect import CallerCategory, ExecutionContext
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_app(backend: str = "typer"):
+    from tooli import Tooli
+
+    app = Tooli(name="test-app", version="1.0.0", backend=backend)
+
+    @app.command()
+    def greet(name: str) -> dict:
+        """Greet someone."""
+        return {"message": f"Hello, {name}!"}
+
+    @app.command(name="find-files")
+    def find_files(pattern: str) -> list:
+        """Find files."""
+        return [{"path": pattern}]
+
+    @app.command()
+    def no_args() -> str:
+        return "ok"
+
+    return app
+
+
+# ---------------------------------------------------------------------------
+# get_command()
+# ---------------------------------------------------------------------------
+
+
+class TestGetCommand:
+    def test_get_command_by_name(self):
+        app = _make_app()
+        cb = app.get_command("greet")
+        assert cb is not None
+        assert callable(cb)
+
+    def test_get_command_hyphen_name(self):
+        app = _make_app()
+        cb = app.get_command("find-files")
+        assert cb is not None
+
+    def test_get_command_underscore_name(self):
+        app = _make_app()
+        cb = app.get_command("find_files")
+        assert cb is not None
+
+    def test_get_command_not_found(self):
+        app = _make_app()
+        cb = app.get_command("nonexistent")
+        assert cb is None
+
+    def test_get_command_native_backend(self):
+        app = _make_app(backend="native")
+        cb = app.get_command("greet")
+        assert cb is not None
+
+    def test_get_command_callback_works(self):
+        app = _make_app()
+        cb = app.get_command("greet")
+        result = cb(name="World")
+        assert result == {"message": "Hello, World!"}
+
+
+# ---------------------------------------------------------------------------
+# list_commands()
+# ---------------------------------------------------------------------------
+
+
+class TestListCommands:
+    def test_list_commands_includes_registered(self):
+        app = _make_app()
+        cmds = app.list_commands()
+        assert "greet" in cmds
+        assert "find-files" in cmds or "find_files" in cmds
+
+    def test_list_commands_sorted(self):
+        app = _make_app()
+        cmds = app.list_commands()
+        assert cmds == sorted(cmds)
+
+    def test_list_commands_native_backend(self):
+        app = _make_app(backend="native")
+        cmds = app.list_commands()
+        assert "greet" in cmds
+
+
+# ---------------------------------------------------------------------------
+# CallerCategory.PYTHON_API (#150)
+# ---------------------------------------------------------------------------
+
+
+class TestCallerCategoryPythonAPI:
+    def test_python_api_in_enum(self):
+        assert CallerCategory.PYTHON_API == "python_api"
+
+    def test_is_agent_false_for_python_api(self):
+        ctx = ExecutionContext(
+            category=CallerCategory.PYTHON_API,
+            agent_name=None,
+            confidence=1.0,
+            signals=[],
+            is_interactive=False,
+        )
+        assert ctx.is_agent is False
+
+    def test_is_human_false_for_python_api(self):
+        ctx = ExecutionContext(
+            category=CallerCategory.PYTHON_API,
+            agent_name=None,
+            confidence=1.0,
+            signals=[],
+            is_interactive=False,
+        )
+        assert ctx.is_human is False
+
+    def test_call_sets_caller_id(self):
+        app = _make_app()
+        result = app.call("greet", name="World")
+        assert result.meta["caller_id"] == "python-api"
+
+    def test_acall_meta_caller_id(self):
+        """Verify acall also sets caller_id in meta."""
+        import asyncio
+
+        app = _make_app()
+        result = asyncio.run(app.acall("greet", name="World"))
+        assert result.meta["caller_id"] == "python-api"


### PR DESCRIPTION
## Summary
- Adds `acall()` async Python API to both Typer and native backends — async commands are awaited directly, sync commands run via `asyncio.to_thread()`
- Adds `get_command()` method for direct callback lookup by name (hyphens/underscores)
- Adds `asyncio_mode = "auto"` pytest config for pytest-asyncio support
- Adds explicit test coverage for `CallerCategory.PYTHON_API` detection and telemetry integration (both were already implemented in #147 but lacked dedicated tests)
- 34 new tests (20 acall, 14 accessors/PYTHON_API)

## Test plan
- [x] `pytest -x -q --ignore=tests/test_export.py` — 468 passed, 1 xfailed
- [x] `ruff check` clean on all new/modified files
- [x] Both Typer and native backends tested for `acall()` and `get_command()`
- [x] Async and sync command paths both covered
- [x] Error handling, dry-run, and edge cases tested

Closes #148, closes #149, closes #150, closes #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)