### PR TITLE
Add capabilities, handoffs, and error field mapping (#158-#160)

### DIFF
--- a/tests/test_capabilities_handoffs_field.py
+++ b/tests/test_capabilities_handoffs_field.py
@@ -1,0 +1,300 @@
+"""Tests for capabilities (#158), handoffs (#159), and error field mapping (#160)."""
+
+from __future__ import annotations
+
+from tooli.annotations import Destructive, ReadOnly
+from tooli.command_meta import CommandMeta, get_command_meta
+from tooli.errors import (
+    AuthError,
+    InputError,
+    InternalError,
+    StateError,
+    ToolError,
+    ToolRuntimeError,
+)
+from tooli.python_api import TooliError
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_app(backend: str = "typer"):
+    from tooli import Tooli
+
+    app = Tooli(name="test-app", help="Test app", version="1.0.0")
+
+    @app.command(
+        annotations=ReadOnly,
+        capabilities=["fs:read", "net:read"],
+        handoffs=[
+            {"command": "process", "when": "After finding files to analyze"},
+            {"command": "rename-files", "when": "To rename matched files"},
+        ],
+        delegation_hint="Use an agent with filesystem access",
+    )
+    def find_files(pattern: str, root: str = ".") -> list:
+        """Find files matching a pattern."""
+        return [{"path": f"{root}/{pattern}"}]
+
+    @app.command(
+        annotations=Destructive,
+        capabilities=["fs:write", "fs:delete"],
+    )
+    def delete_item(item_id: str) -> dict:
+        """Delete an item by ID."""
+        return {"deleted": item_id}
+
+    @app.command()
+    def simple() -> str:
+        """A simple command with no capabilities."""
+        return "ok"
+
+    @app.command()
+    def fail_with_field(value: str) -> dict:
+        """Command that raises with field info."""
+        raise InputError(
+            message=f"Invalid pattern: {value}",
+            code="E1003",
+            field="value",
+        )
+
+    return app
+
+
+# ---------------------------------------------------------------------------
+# #158 — Capabilities
+# ---------------------------------------------------------------------------
+
+
+class TestCapabilities:
+    def test_capabilities_stored_on_meta(self):
+        app = _make_app()
+        cb = app.get_command("find-files")
+        meta = get_command_meta(cb)
+        assert meta.capabilities == ["fs:read", "net:read"]
+
+    def test_capabilities_empty_by_default(self):
+        app = _make_app()
+        cb = app.get_command("simple")
+        meta = get_command_meta(cb)
+        assert meta.capabilities == []
+
+    def test_capabilities_in_manifest(self):
+        from tooli.manifest import generate_agent_manifest
+
+        app = _make_app()
+        manifest = generate_agent_manifest(app)
+        find_cmd = next(c for c in manifest["commands"] if c["name"] == "find_files" or "find" in c["name"])
+        assert "capabilities" in find_cmd
+        assert "fs:read" in find_cmd["capabilities"]
+
+    def test_capabilities_not_in_manifest_when_empty(self):
+        from tooli.manifest import generate_agent_manifest
+
+        app = _make_app()
+        manifest = generate_agent_manifest(app)
+        simple_cmd = next(c for c in manifest["commands"] if c["name"] == "simple")
+        assert "capabilities" not in simple_cmd
+
+    def test_capabilities_in_schema(self):
+        from tooli.schema import generate_tool_schema
+
+        app = _make_app()
+        cb = app.get_command("find-files")
+        schema = generate_tool_schema(cb, name="find-files")
+        assert schema.capabilities == ["fs:read", "net:read"]
+
+    def test_capabilities_in_skill_md(self):
+        from tooli.docs.skill_v4 import SkillV4Generator
+
+        app = _make_app()
+        content = SkillV4Generator(app).generate()
+        assert "fs:read" in content
+
+    def test_capabilities_in_agents_md(self):
+        from tooli.docs.agents_md import generate_agents_md
+
+        app = _make_app()
+        content = generate_agents_md(app)
+        assert "fs:read" in content
+
+    def test_capabilities_in_claude_md(self):
+        from tooli.docs.claude_md_v2 import generate_claude_md_v2
+
+        app = _make_app()
+        content = generate_claude_md_v2(app)
+        assert "fs:read" in content
+
+    def test_capabilities_native_backend(self):
+        from tooli import Tooli
+
+        app = Tooli(name="native-test", version="1.0.0", backend="native")
+
+        @app.command(capabilities=["fs:read"])
+        def read_file(path: str) -> str:
+            return "content"
+
+        meta = get_command_meta(read_file)
+        assert meta.capabilities == ["fs:read"]
+
+
+# ---------------------------------------------------------------------------
+# #159 — Handoffs
+# ---------------------------------------------------------------------------
+
+
+class TestHandoffs:
+    def test_handoffs_stored_on_meta(self):
+        app = _make_app()
+        cb = app.get_command("find-files")
+        meta = get_command_meta(cb)
+        assert len(meta.handoffs) == 2
+        assert meta.handoffs[0]["command"] == "process"
+        assert meta.handoffs[0]["when"] == "After finding files to analyze"
+
+    def test_handoffs_empty_by_default(self):
+        app = _make_app()
+        cb = app.get_command("simple")
+        meta = get_command_meta(cb)
+        assert meta.handoffs == []
+
+    def test_delegation_hint_stored(self):
+        app = _make_app()
+        cb = app.get_command("find-files")
+        meta = get_command_meta(cb)
+        assert meta.delegation_hint == "Use an agent with filesystem access"
+
+    def test_delegation_hint_none_by_default(self):
+        app = _make_app()
+        cb = app.get_command("simple")
+        meta = get_command_meta(cb)
+        assert meta.delegation_hint is None
+
+    def test_handoffs_in_manifest(self):
+        from tooli.manifest import generate_agent_manifest
+
+        app = _make_app()
+        manifest = generate_agent_manifest(app)
+        find_cmd = next(c for c in manifest["commands"] if "find" in c["name"])
+        assert "handoffs" in find_cmd
+        assert len(find_cmd["handoffs"]) == 2
+
+    def test_delegation_hint_in_manifest(self):
+        from tooli.manifest import generate_agent_manifest
+
+        app = _make_app()
+        manifest = generate_agent_manifest(app)
+        find_cmd = next(c for c in manifest["commands"] if "find" in c["name"])
+        assert find_cmd["delegation_hint"] == "Use an agent with filesystem access"
+
+    def test_handoffs_not_in_manifest_when_empty(self):
+        from tooli.manifest import generate_agent_manifest
+
+        app = _make_app()
+        manifest = generate_agent_manifest(app)
+        simple_cmd = next(c for c in manifest["commands"] if c["name"] == "simple")
+        assert "handoffs" not in simple_cmd
+        assert "delegation_hint" not in simple_cmd
+
+    def test_handoffs_in_skill_md(self):
+        from tooli.docs.skill_v4 import SkillV4Generator
+
+        app = _make_app()
+        content = SkillV4Generator(app).generate()
+        assert "process" in content
+        assert "Handoff" in content
+
+    def test_handoffs_in_agents_md(self):
+        from tooli.docs.agents_md import generate_agents_md
+
+        app = _make_app()
+        content = generate_agents_md(app)
+        assert "process" in content
+        assert "Next steps" in content
+
+    def test_handoffs_in_schema(self):
+        from tooli.schema import generate_tool_schema
+
+        app = _make_app()
+        cb = app.get_command("find-files")
+        schema = generate_tool_schema(cb, name="find-files")
+        assert len(schema.handoffs) == 2
+        assert schema.delegation_hint == "Use an agent with filesystem access"
+
+
+# ---------------------------------------------------------------------------
+# #160 — Error field mapping
+# ---------------------------------------------------------------------------
+
+
+class TestErrorField:
+    def test_tool_error_field_attribute(self):
+        err = ToolError("bad input", code="E1000", field="pattern")
+        assert err.field == "pattern"
+
+    def test_tool_error_field_none_by_default(self):
+        err = ToolError("bad input", code="E1000")
+        assert err.field is None
+
+    def test_input_error_field(self):
+        err = InputError("bad value", field="value")
+        assert err.field == "value"
+
+    def test_auth_error_field(self):
+        err = AuthError("no access", field="token")
+        assert err.field == "token"
+
+    def test_state_error_field(self):
+        err = StateError("not found", field="item_id")
+        assert err.field == "item_id"
+
+    def test_runtime_error_field(self):
+        err = ToolRuntimeError("timeout", field="url")
+        assert err.field == "url"
+
+    def test_internal_error_field(self):
+        err = InternalError("crash", field="config")
+        assert err.field == "config"
+
+    def test_to_dict_includes_field(self):
+        err = InputError("bad pattern", code="E1003", field="pattern")
+        d = err.to_dict()
+        assert d["field"] == "pattern"
+
+    def test_to_dict_excludes_field_when_none(self):
+        err = InputError("bad pattern", code="E1003")
+        d = err.to_dict()
+        assert "field" not in d
+
+    def test_tooli_error_from_tool_error_preserves_field(self):
+        err = InputError("bad pattern", code="E1003", field="pattern")
+        tooli_err = TooliError.from_tool_error(err)
+        assert tooli_err.field == "pattern"
+
+    def test_tooli_error_field_override(self):
+        err = InputError("bad pattern", code="E1003")
+        tooli_err = TooliError.from_tool_error(err, field="pattern")
+        assert tooli_err.field == "pattern"
+
+    def test_field_in_python_api_result(self):
+        app = _make_app()
+        result = app.call("fail-with-field", value="[invalid")
+        assert result.ok is False
+        assert result.error.field == "value"
+
+    def test_field_in_unwrap_exception(self):
+        import pytest
+
+        app = _make_app()
+        result = app.call("fail-with-field", value="[invalid")
+        with pytest.raises(InputError) as exc_info:
+            result.unwrap()
+        assert exc_info.value.field == "value"
+
+    def test_commandmeta_default_has_no_field(self):
+        """Verify CommandMeta doesn't break — field is on errors, not meta."""
+        meta = CommandMeta()
+        assert meta.capabilities == []
+        assert meta.handoffs == []
+        assert meta.delegation_hint is None

--- a/tooli/app.py
+++ b/tooli/app.py
@@ -998,6 +998,9 @@ class Tooli(typer.Typer):
         expected_outputs: list[dict[str, Any]] | None = None,
         recovery_playbooks: dict[str, list[str]] | None = None,
         task_group: str | None = None,
+        capabilities: list[str] | None = None,
+        handoffs: list[dict[str, str]] | None = None,
+        delegation_hint: str | None = None,
         **kwargs: Any,
     ) -> Any:
         """Register a command using Tooli defaults and metadata.
@@ -1105,6 +1108,9 @@ class Tooli(typer.Typer):
                 expected_outputs=expected_outputs or [],
                 recovery_playbooks=recovery_playbooks or {},
                 task_group=task_group,
+                capabilities=capabilities or [],
+                handoffs=handoffs or [],
+                delegation_hint=delegation_hint,
             )
             func.__tooli_meta__ = meta
 

--- a/tooli/app_native.py
+++ b/tooli/app_native.py
@@ -182,6 +182,9 @@ class Tooli:
         expected_outputs: list[dict[str, Any]] | None = None,
         recovery_playbooks: dict[str, list[str]] | None = None,
         task_group: str | None = None,
+        capabilities: list[str] | None = None,
+        handoffs: list[dict[str, str]] | None = None,
+        delegation_hint: str | None = None,
         **kwargs: Any,
     ) -> Any:
         _ = list_processing
@@ -243,6 +246,9 @@ class Tooli:
                 expected_outputs=expected_outputs or [],
                 recovery_playbooks=recovery_playbooks or {},
                 task_group=task_group,
+                capabilities=capabilities or [],
+                handoffs=handoffs or [],
+                delegation_hint=delegation_hint,
             )
             func.__tooli_meta__ = meta
 

--- a/tooli/command_meta.py
+++ b/tooli/command_meta.py
@@ -60,6 +60,11 @@ class CommandMeta:
     recovery_playbooks: dict[str, list[str]] = field(default_factory=dict)
     task_group: str | None = None
 
+    # v5 fields
+    capabilities: list[str] = field(default_factory=list)
+    handoffs: list[dict[str, str]] = field(default_factory=list)
+    delegation_hint: str | None = None
+
 
 def get_command_meta(callback: Callable[..., Any] | None) -> CommandMeta:
     """Retrieve CommandMeta from a callback, with safe defaults."""

--- a/tooli/docs/agents_md.py
+++ b/tooli/docs/agents_md.py
@@ -159,6 +159,29 @@ def generate_agents_md(app: Any) -> str:
             lines.append(f"**Behavior:** {', '.join(labels)}")
             lines.append("")
 
+        # Capabilities
+        meta = get_command_meta(callback)
+        if meta.capabilities:
+            lines.append(f"**Capabilities:** `{', '.join(meta.capabilities)}`")
+            lines.append("")
+
+        # Delegation hint
+        if meta.delegation_hint:
+            lines.append(f"**Delegation:** {meta.delegation_hint}")
+            lines.append("")
+
+        # Handoffs
+        if meta.handoffs:
+            lines.append("**Next steps:**")
+            for handoff in meta.handoffs:
+                target = handoff.get("command", "")
+                when = handoff.get("when", "")
+                if target and when:
+                    lines.append(f"- `{target}`: {when}")
+                elif target:
+                    lines.append(f"- `{target}`")
+            lines.append("")
+
     # Output Format
     lines.extend([
         "## Output Format",

--- a/tooli/docs/claude_md_v2.py
+++ b/tooli/docs/claude_md_v2.py
@@ -84,17 +84,19 @@ def generate_claude_md_v2(app: Any) -> str:
         labels = _annotation_labels(tool_def.callback)
         label_str = f" [{', '.join(labels)}]" if labels else ""
 
+        cap_str = f" needs:{','.join(meta.capabilities)}" if meta.capabilities else ""
+
         examples = meta.examples
         if examples:
             first = examples[0]
             args = first.get("args", [])
             if isinstance(args, list):
                 arg_text = " ".join(str(a) for a in args if a is not None)
-                lines.append(f"- `{app_name} {tool_def.name} {arg_text}`{label_str}")
+                lines.append(f"- `{app_name} {tool_def.name} {arg_text}`{label_str}{cap_str}")
             else:
-                lines.append(f"- `{app_name} {tool_def.name}`{label_str}")
+                lines.append(f"- `{app_name} {tool_def.name}`{label_str}{cap_str}")
         else:
-            lines.append(f"- `{app_name} {tool_def.name}`{label_str}")
+            lines.append(f"- `{app_name} {tool_def.name}`{label_str}{cap_str}")
 
     lines.append("")
 

--- a/tooli/errors.py
+++ b/tooli/errors.py
@@ -48,6 +48,7 @@ class ToolError(Exception):
         is_retryable: bool = False,
         details: dict[str, Any] | None = None,
         exit_code: ExitCode | int | None = None,
+        field: str | None = None,
     ) -> None:
         super().__init__(message)
         self.message = message
@@ -56,6 +57,7 @@ class ToolError(Exception):
         self.suggestion = suggestion
         self.is_retryable = is_retryable
         self.details = details or {}
+        self.field = field
         resolved_exit_code = exit_code if exit_code is not None else _default_exit_code(category)
         if isinstance(resolved_exit_code, ExitCode):
             self.exit_code = int(resolved_exit_code)
@@ -63,7 +65,7 @@ class ToolError(Exception):
             self.exit_code = resolved_exit_code
 
     def to_dict(self) -> dict[str, Any]:
-        return {
+        result: dict[str, Any] = {
             "message": self.message,
             "code": self.code,
             "category": self.category.value,
@@ -71,6 +73,9 @@ class ToolError(Exception):
             "is_retryable": self.is_retryable,
             "details": self.details,
         }
+        if self.field is not None:
+            result["field"] = self.field
+        return result
 
 
 class InputError(ToolError):
@@ -82,6 +87,7 @@ class InputError(ToolError):
         code: str = "E1000",
         suggestion: Suggestion | None = None,
         details: dict[str, Any] | None = None,
+        field: str | None = None,
     ) -> None:
         super().__init__(
             message,
@@ -90,6 +96,7 @@ class InputError(ToolError):
             suggestion=suggestion,
             details=details,
             exit_code=ExitCode.INVALID_INPUT,
+            field=field,
         )
 
 
@@ -102,6 +109,7 @@ class AuthError(ToolError):
         code: str = "E2000",
         suggestion: Suggestion | None = None,
         details: dict[str, Any] | None = None,
+        field: str | None = None,
     ) -> None:
         super().__init__(
             message,
@@ -110,6 +118,7 @@ class AuthError(ToolError):
             suggestion=suggestion,
             details=details,
             exit_code=ExitCode.AUTH_DENIED,
+            field=field,
         )
 
 
@@ -123,6 +132,7 @@ class StateError(ToolError):
         suggestion: Suggestion | None = None,
         details: dict[str, Any] | None = None,
         exit_code: ExitCode | int = ExitCode.STATE_ERROR,
+        field: str | None = None,
     ) -> None:
         super().__init__(
             message,
@@ -131,6 +141,7 @@ class StateError(ToolError):
             suggestion=suggestion,
             details=details,
             exit_code=exit_code,
+            field=field,
         )
 
 
@@ -144,6 +155,7 @@ class ToolRuntimeError(ToolError):
         suggestion: Suggestion | None = None,
         details: dict[str, Any] | None = None,
         exit_code: int = 70,
+        field: str | None = None,
     ) -> None:
         super().__init__(
             message,
@@ -152,6 +164,7 @@ class ToolRuntimeError(ToolError):
             suggestion=suggestion,
             details=details,
             exit_code=exit_code,
+            field=field,
         )
 
 
@@ -164,6 +177,7 @@ class InternalError(ToolError):
         code: str = "E5000",
         suggestion: Suggestion | None = None,
         details: dict[str, Any] | None = None,
+        field: str | None = None,
     ) -> None:
         super().__init__(
             message,
@@ -172,4 +186,5 @@ class InternalError(ToolError):
             suggestion=suggestion,
             details=details,
             exit_code=ExitCode.INTERNAL_ERROR,
+            field=field,
         )

--- a/tooli/manifest.py
+++ b/tooli/manifest.py
@@ -105,6 +105,12 @@ def generate_agent_manifest(app: "Tooli") -> dict[str, Any]:
             entry["task_group"] = meta.task_group
         if meta.when_to_use is not None:
             entry["when_to_use"] = meta.when_to_use
+        if meta.capabilities:
+            entry["capabilities"] = meta.capabilities
+        if meta.handoffs:
+            entry["handoffs"] = meta.handoffs
+        if meta.delegation_hint is not None:
+            entry["delegation_hint"] = meta.delegation_hint
         commands.append(entry)
         error_entries.extend(_command_error_catalog_entries(tool_def.name, meta))
 
@@ -139,6 +145,7 @@ def generate_agent_manifest(app: "Tooli") -> dict[str, Any]:
                     "code": "E0000",
                     "category": "runtime",
                     "message": "See command output for details.",
+                    "field": None,
                 },
                 "meta": {
                     "tool": f"{name}.<command>",

--- a/tooli/python_api.py
+++ b/tooli/python_api.py
@@ -66,6 +66,7 @@ class TooliError:
             code=self.code,
             suggestion=suggestion_obj,
             details=self.details if self.details else None,
+            field=self.field,
         )
 
     @classmethod
@@ -80,7 +81,7 @@ class TooliError:
             message=err.message,
             suggestion=suggestion_dict,
             is_retryable=err.is_retryable,
-            field=field,
+            field=field or err.field,
             details=err.details,
         )
 

--- a/tooli/schema.py
+++ b/tooli/schema.py
@@ -23,6 +23,9 @@ class ToolSchema(BaseModel):
     examples: list[dict[str, Any]] = Field(default_factory=list)
     deprecated: bool = False
     deprecated_message: str | None = None
+    capabilities: list[str] = Field(default_factory=list)
+    handoffs: list[dict[str, str]] = Field(default_factory=list)
+    delegation_hint: str | None = None
 
 
 def _dereference_refs(schema: dict[str, Any], root_schema: dict[str, Any] | None = None) -> dict[str, Any]:
@@ -159,4 +162,7 @@ def generate_tool_schema(
         deprecated=meta.deprecated,
         deprecated_message=meta.deprecated_message,
         auth=required_scopes or list(meta.auth),
+        capabilities=list(meta.capabilities),
+        handoffs=list(meta.handoffs),
+        delegation_hint=meta.delegation_hint,
     )


### PR DESCRIPTION
## Summary
- Adds granular **capability declarations** (`capabilities=["fs:read", "net:write"]`) to command metadata, surfaced in manifest, JSON schema, SKILL.md, AGENTS.md, and CLAUDE.md
- Adds **handoff metadata** (`handoffs=[{"command": "process", "when": "..."}]`) and `delegation_hint` for multi-agent workflow orchestration, surfaced in manifest, schema, SKILL.md composition patterns, and AGENTS.md next-steps
- Adds **`field` parameter** to `ToolError` and all subclasses, linking errors to the specific input parameter that caused them — carries through `to_dict()`, `TooliError`, and `unwrap()` round-trip
- 33 new tests covering all three features across metadata storage, manifest, schema, doc generators, and Python API

## Test plan
- [x] `pytest -x -q --ignore=tests/test_export.py` — 501 passed, 1 xfailed
- [x] `ruff check` clean on all new/modified files
- [x] Capabilities: stored on meta, in manifest/schema/SKILL.md/AGENTS.md/CLAUDE.md
- [x] Handoffs: stored on meta, in manifest/schema/SKILL.md composition patterns/AGENTS.md
- [x] Error field: all 5 error subclasses, to_dict(), TooliError round-trip, Python API result

Closes #158, closes #159, closes #160

🤖 Generated with [Claude Code](https://claude.com/claude-code)