### PR TITLE
Add capability enforcement and output schema in envelope (#161-#163)

### DIFF
--- a/tests/test_output_schema.py
+++ b/tests/test_output_schema.py
@@ -1,0 +1,104 @@
+"""Tests for output schema in envelope meta (#163)."""
+
+from __future__ import annotations
+
+import json
+
+from typer.testing import CliRunner
+
+from tooli import Tooli
+
+
+def _make_app():
+    app = Tooli(name="schema-app", version="1.0.0")
+
+    @app.command()
+    def greet(name: str) -> dict:
+        """Greet someone."""
+        return {"message": f"Hello, {name}!"}
+
+    @app.command()
+    def count(n: int) -> list:
+        """Count to n."""
+        return list(range(n))
+
+    @app.command()
+    def no_return(name: str):
+        """Command with no return type."""
+        pass
+
+    return app
+
+
+class TestOutputSchemaInEnvelope:
+    def test_concise_mode_omits_schema(self):
+        app = _make_app()
+        runner = CliRunner()
+        result = runner.invoke(app, ["greet", "World", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["ok"] is True
+        assert data["meta"].get("output_schema") is None
+
+    def test_detailed_mode_includes_schema(self):
+        app = _make_app()
+        runner = CliRunner()
+        result = runner.invoke(app, ["greet", "World", "--json", "--response-format", "detailed"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["ok"] is True
+        schema = data["meta"].get("output_schema")
+        assert schema is not None
+        assert schema.get("type") is not None
+
+    def test_env_var_includes_schema(self, monkeypatch):
+        monkeypatch.setenv("TOOLI_INCLUDE_SCHEMA", "true")
+        app = _make_app()
+        runner = CliRunner()
+        result = runner.invoke(app, ["greet", "World", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        schema = data["meta"].get("output_schema")
+        assert schema is not None
+
+    def test_env_var_1_includes_schema(self, monkeypatch):
+        monkeypatch.setenv("TOOLI_INCLUDE_SCHEMA", "1")
+        app = _make_app()
+        runner = CliRunner()
+        result = runner.invoke(app, ["count", "3", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        schema = data["meta"].get("output_schema")
+        assert schema is not None
+
+    def test_schema_infer_returns_correct_type(self):
+        """Verify the inferred schema matches the return type."""
+        app = _make_app()
+        runner = CliRunner()
+        result = runner.invoke(app, ["count", "3", "--json", "--response-format", "detailed"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        schema = data["meta"].get("output_schema")
+        assert schema is not None
+        # list return type should produce array schema
+        assert schema.get("type") == "array"
+
+    def test_text_mode_unaffected(self):
+        app = _make_app()
+        runner = CliRunner()
+        result = runner.invoke(app, ["greet", "World", "--text", "--response-format", "detailed"])
+        assert result.exit_code == 0
+        # Text mode doesn't use envelope at all
+        assert "output_schema" not in result.output
+
+    def test_envelope_meta_model_has_output_schema_field(self):
+        from tooli.envelope import EnvelopeMeta
+        meta = EnvelopeMeta(tool="test", version="1.0.0", duration_ms=1, output_schema={"type": "object"})
+        d = meta.model_dump()
+        assert d["output_schema"] == {"type": "object"}
+
+    def test_envelope_meta_output_schema_none_by_default(self):
+        from tooli.envelope import EnvelopeMeta
+        meta = EnvelopeMeta(tool="test", version="1.0.0", duration_ms=1)
+        d = meta.model_dump()
+        assert d["output_schema"] is None

--- a/tests/test_security_capabilities.py
+++ b/tests/test_security_capabilities.py
@@ -1,0 +1,148 @@
+"""Tests for security policy capability enforcement (#162)."""
+
+from __future__ import annotations
+
+import json
+
+from typer.testing import CliRunner
+
+from tooli import Tooli
+from tooli.annotations import Destructive, ReadOnly
+
+
+def _find_envelope(output: str) -> dict:
+    """Find the error envelope line in output (may include audit events on stderr)."""
+    for line in output.strip().splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            data = json.loads(line)
+            if "ok" in data:
+                return data
+        except (json.JSONDecodeError, ValueError):
+            continue
+    msg = f"No envelope found in output: {output!r}"
+    raise ValueError(msg)
+
+
+def test_strict_mode_blocks_denied_capabilities(monkeypatch) -> None:
+    monkeypatch.setenv("TOOLI_ALLOWED_CAPABILITIES", "fs:read,net:read")
+
+    app = Tooli(name="sec-app", security_policy="strict")
+    runner = CliRunner()
+
+    @app.command(capabilities=["fs:read", "fs:write"])
+    def write_files(path: str) -> str:
+        return f"wrote {path}"
+
+    result = runner.invoke(app, ["write-files", "test.txt", "--json"])
+    assert result.exit_code != 0
+    data = _find_envelope(result.output)
+    assert data["ok"] is False
+    assert "fs:write" in data["error"]["message"]
+    assert data["error"]["code"] == "E2002"
+
+
+def test_strict_mode_allows_matching_capabilities(monkeypatch) -> None:
+    monkeypatch.setenv("TOOLI_ALLOWED_CAPABILITIES", "fs:read,net:read")
+
+    app = Tooli(name="sec-app", security_policy="strict")
+    runner = CliRunner()
+
+    @app.command(annotations=ReadOnly, capabilities=["fs:read"])
+    def read_files(path: str) -> str:
+        return f"read {path}"
+
+    result = runner.invoke(app, ["read-files", "test.txt", "--text"])
+    assert result.exit_code == 0
+    assert "read test.txt" in result.output
+
+
+def test_strict_mode_wildcard_capabilities(monkeypatch) -> None:
+    monkeypatch.setenv("TOOLI_ALLOWED_CAPABILITIES", "fs:*")
+
+    app = Tooli(name="sec-app", security_policy="strict")
+    runner = CliRunner()
+
+    @app.command(capabilities=["fs:read", "fs:write", "fs:delete"])
+    def manage_files(action: str) -> str:
+        return f"done: {action}"
+
+    result = runner.invoke(app, ["manage-files", "cleanup", "--text"])
+    assert result.exit_code == 0
+
+
+def test_no_allowlist_skips_enforcement(monkeypatch) -> None:
+    monkeypatch.delenv("TOOLI_ALLOWED_CAPABILITIES", raising=False)
+
+    app = Tooli(name="sec-app", security_policy="strict")
+    runner = CliRunner()
+
+    @app.command(capabilities=["fs:write", "net:write"])
+    def dangerous_op() -> str:
+        return "executed"
+
+    # No --yes needed since not destructive annotation
+    result = runner.invoke(app, ["dangerous-op", "--text"])
+    assert result.exit_code == 0
+
+
+def test_standard_mode_ignores_capability_enforcement(monkeypatch) -> None:
+    monkeypatch.setenv("TOOLI_ALLOWED_CAPABILITIES", "fs:read")
+
+    app = Tooli(name="sec-app", security_policy="standard")
+    runner = CliRunner()
+
+    @app.command(capabilities=["fs:write"])
+    def write_op() -> str:
+        return "wrote"
+
+    result = runner.invoke(app, ["write-op", "--text"])
+    assert result.exit_code == 0
+
+
+def test_off_mode_ignores_capability_enforcement(monkeypatch) -> None:
+    monkeypatch.setenv("TOOLI_ALLOWED_CAPABILITIES", "fs:read")
+
+    app = Tooli(name="sec-app", security_policy="off")
+    runner = CliRunner()
+
+    @app.command(capabilities=["fs:write"])
+    def write_op() -> str:
+        return "wrote"
+
+    result = runner.invoke(app, ["write-op", "--text"])
+    assert result.exit_code == 0
+
+
+def test_no_capabilities_skips_enforcement(monkeypatch) -> None:
+    monkeypatch.setenv("TOOLI_ALLOWED_CAPABILITIES", "fs:read")
+
+    app = Tooli(name="sec-app", security_policy="strict")
+    runner = CliRunner()
+
+    @app.command()
+    def simple() -> str:
+        return "ok"
+
+    result = runner.invoke(app, ["simple", "--text"])
+    assert result.exit_code == 0
+
+
+def test_destructive_still_requires_confirmation_in_strict() -> None:
+    """Verify existing destructive enforcement isn't broken."""
+    app = Tooli(name="sec-app", security_policy="strict")
+    runner = CliRunner()
+
+    @app.command(annotations=Destructive, capabilities=["fs:delete"])
+    def wipe() -> str:
+        return "wiped"
+
+    # Without --yes, should be blocked
+    denied = runner.invoke(app, ["wipe", "--text"])
+    assert denied.exit_code == 2
+
+    # With --yes, should work (no allowlist, so no capability block)
+    with_yes = runner.invoke(app, ["wipe", "--yes", "--text"])
+    assert with_yes.exit_code == 0

--- a/tooli/envelope.py
+++ b/tooli/envelope.py
@@ -20,6 +20,7 @@ class EnvelopeMeta(BaseModel):
     caller_id: str | None = None
     caller_version: str | None = None
     session_id: str | None = None
+    output_schema: dict[str, Any] | None = None
 
 
 class Envelope(BaseModel):


### PR DESCRIPTION
## Summary
- **#161**: Capability and handoff rendering was already implemented in PR #172 — this PR closes the issue
- **#162**: Adds `TOOLI_ALLOWED_CAPABILITIES` enforcement in STRICT security mode — commands with undeclared capabilities are blocked with `AuthError E2002`. Supports wildcard matching (`fs:*`). STANDARD/OFF modes skip enforcement. No allowlist = no enforcement.
- **#163**: Adds `output_schema` field to `EnvelopeMeta`, populated from return type annotation via Pydantic `TypeAdapter` when `--response-format detailed` or `TOOLI_INCLUDE_SCHEMA=true` env var is set. Omitted in concise mode (default) to save tokens.
- 16 new tests (8 security capabilities, 8 output schema)

## Test plan
- [x] `pytest -x -q --ignore=tests/test_export.py` — 517 passed, 1 xfailed
- [x] `ruff check` clean on all new/modified files (1 pre-existing B007)
- [x] STRICT mode blocks denied capabilities, allows matching/wildcard
- [x] STANDARD/OFF modes skip capability enforcement
- [x] Detailed response format includes output schema
- [x] TOOLI_INCLUDE_SCHEMA env var includes schema
- [x] Concise mode omits schema
- [x] Existing security and auth tests unaffected

Closes #161, closes #162, closes #163

🤖 Generated with [Claude Code](https://claude.com/claude-code)