### PR TITLE
Release 6.2.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tooli"
-version = "6.1.0"
+version = "6.2.1"
 description = "The agent-native CLI framework for Python"
 readme = "pypi/pypi_project.md"
 requires-python = ">=3.10"

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -61,6 +61,53 @@ def test_security_policy_defaults_to_standard() -> None:
     assert with_yes.exit_code == 0
 
 
+def test_tooli_yes_env_var_skips_confirmation(monkeypatch) -> None:
+    monkeypatch.setenv("TOOLI_YES", "1")
+    monkeypatch.delenv("TOOLI_NONINTERACTIVE", raising=False)
+
+    app = Tooli(name="sec-app", security_policy="standard")
+    runner = CliRunner()
+
+    @app.command(annotations=Destructive)
+    def wipe() -> str:
+        return "removed"
+
+    result = runner.invoke(app, ["wipe", "--text"])
+    assert result.exit_code == 0
+    assert result.output.strip().endswith("removed")
+
+
+def test_tooli_noninteractive_env_var_skips_confirmation(monkeypatch) -> None:
+    monkeypatch.setenv("TOOLI_NONINTERACTIVE", "yes")
+    monkeypatch.delenv("TOOLI_YES", raising=False)
+
+    app = Tooli(name="sec-app", security_policy="standard")
+    runner = CliRunner()
+
+    @app.command(annotations=Destructive)
+    def wipe() -> str:
+        return "removed"
+
+    result = runner.invoke(app, ["wipe", "--text"])
+    assert result.exit_code == 0
+    assert result.output.strip().endswith("removed")
+
+
+def test_tooli_yes_env_var_false_does_not_skip_confirmation(monkeypatch) -> None:
+    monkeypatch.setenv("TOOLI_YES", "0")
+    monkeypatch.delenv("TOOLI_NONINTERACTIVE", raising=False)
+
+    app = Tooli(name="sec-app", security_policy="standard")
+    runner = CliRunner()
+
+    @app.command(annotations=Destructive)
+    def wipe() -> str:
+        return "removed"
+
+    result = runner.invoke(app, ["wipe", "--text"])
+    assert result.exit_code == 2
+
+
 @pytest.mark.parametrize(
     "value, expected_mode",
     [

--- a/tooli/__init__.py
+++ b/tooli/__init__.py
@@ -31,7 +31,7 @@ class Tooli:
         return _TyperTooli(*args, backend=backend, **kwargs)
 
 
-__version__ = "6.1.0"
+__version__ = "6.2.1"
 __all__ = [
     "Annotated",
     "Argument",


### PR DESCRIPTION
## Summary\n- add TOOLI_YES / TOOLI_NONINTERACTIVE env override for destructive confirmations\n- add coverage for env-based yes-override behavior\n- bump package version from 6.1.0 to 6.2.1\n\n## Validation\n- uv run --extra dev pytest -q tests/test_security.py tests/test_security_capabilities.py tests/test_app.py